### PR TITLE
Fixing a bug in asyncValidate function

### DIFF
--- a/src/asyncValidate.ts
+++ b/src/asyncValidate.ts
@@ -11,7 +11,7 @@ const asyncValidate = <T>(schema: Schema<T>) => {
                 errors.inner.forEach((error) => {
                     set(formErrors, error.path, error.message);
                 });
-                return formErrors;
+                throw formErrors;
             });
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import asyncValidate from "./asyncValidate";
 import shouldAsyncValidate from "./shouldAsyncValidate";
+import syncValidate from "./syncValidate";
 
 export {
     asyncValidate,
     shouldAsyncValidate,
+    syncValidate
 }


### PR DESCRIPTION
Since redux-form version 7.4 the asyncValidate function does not properly throw validation errors. 

To reject a promise in an async function, an exception has to be raised instead of returning an object. 

Thanks for merging.